### PR TITLE
Fix syntax problem preventing spawning aircraft carriers

### DIFF
--- a/JF-39_AI/CoreMods/aircraft/ChinaAssetPack/JF-39/JF39_Loadouts/jf39_agm_154.lua
+++ b/JF-39_AI/CoreMods/aircraft/ChinaAssetPack/JF-39/JF39_Loadouts/jf39_agm_154.lua
@@ -252,7 +252,7 @@ GB6 =
 
     launcher =
     {
-        cluster = cluster_desc("Bomb_Other", wsType_Bomb_Cluster,
+        cluster = cluster_desc("Bomb_Other", wsType_Bomb_Cluster, levParam),
         {
             scheme = 
             {
@@ -559,7 +559,7 @@ GB6_TSP =
     
     launcher =
     {
-        cluster = cluster_desc("Bomb_Other", wsType_Bomb_Cluster,
+        cluster = cluster_desc("Bomb_Other", wsType_Bomb_Cluster, levParam),
         {
             scheme = 
             {

--- a/JF-39_AI/CoreMods/aircraft/ChinaAssetPack/JF-39/JF39_Loadouts/jf39_dws39.lua
+++ b/JF-39_AI/CoreMods/aircraft/ChinaAssetPack/JF-39/JF39_Loadouts/jf39_dws39.lua
@@ -185,7 +185,7 @@ BK_90 =
     
     launcher =
     {
-        cluster = cluster_desc("Bomb_Other", wsType_Bomb_Cluster, 
+        cluster = cluster_desc("Bomb_Other", wsType_Bomb_Cluster, levParam),
         {
             scheme = 
             {


### PR DESCRIPTION
Fix syntax problem which prevents spawning assets such as aircraft carriers in DCS F/A-18c instant action case1 and case3 missions. The fix was mentioned by Urbi in DCS forum thread - cj43g3r a.k.a. searching46dof